### PR TITLE
Inoue/create informitem

### DIFF
--- a/src/components/molecules/InformItem.js
+++ b/src/components/molecules/InformItem.js
@@ -3,18 +3,46 @@ import ArrowForwardIosIcon from "@mui/icons-material/ArrowForwardIos";
 import Stack from "@mui/material/Stack";
 import styled from "styled-components";
 import { Typography } from "@mui/material";
+import { IconButton } from "@mui/material";
 
-export const InformItem = () => {
+const createDisplayMessage = (props) => {
+  //   Consider: メッセージやり取りの場合（not つんつん）どのようなテキスト表記にするか
+  //   Consider: そもそも返信済みorつんつん済みのものはinformitemの対象外にするか
+  if (props.message === ":tuntun:") {
+    if (props.isResponseFromTarget) {
+      return `${props.TargetNickname}さんから「つんつん」されました！`;
+    } else {
+      return `${props.TargetNickname}さんを「つんつん」しました！`;
+    }
+  } else {
+    if (props.isResponseFromTarget) {
+      return `${props.TargetNickname}さんからメッセージが届きました！`;
+    } else {
+      return `${props.TargetNickname}さんへのメッセージを送りました！`;
+    }
+  }
+};
+
+export const InformItem = (props) => {
+  const displayMessage = createDisplayMessage(props);
   return (
     <>
-      <Stack direction={{ xs: "column", sm: "row" }}>
-        <Stack direction={{ xs: "column", sm: "row" }}>
-          <TunTunIcon />
-          <Typography variant="p">text</Typography>
-        </Stack>
-        <Stack direction={{ xs: "column", sm: "row" }}>
-          <NotifyCircle />
-          <ArrowForwardIosIcon />
+      <Stack direction="row" justifyContent="space-between" alignItems="center">
+        <StyleStackLeft direction="row" alignItems="center">
+          <div>
+            {/* Consider: 最終履歴がつんつんなのかメッセージなのかでアイコン変える？ */}
+            <TunTunIcon size={30} />
+          </div>
+
+          <Typography variant="p">{displayMessage}</Typography>
+        </StyleStackLeft>
+        <Stack direction="row" justifyContent="flex-end" alignItems="center">
+          {props.isMidoku && <NotifyCircle />}
+
+          {/* Todo: ボタンを押した時にConversationに対象の会話を表示するような処理を追加 */}
+          <IconButton>
+            <ArrowForwardIosIcon />
+          </IconButton>
         </Stack>
       </Stack>
     </>
@@ -22,8 +50,11 @@ export const InformItem = () => {
 };
 
 const NotifyCircle = styled.div`
-  height: 2em;
-  width: 2em;
+  height: 1em;
+  width: 1em;
   background-color: #ff0000;
   border-radius: 50%;
+`;
+const StyleStackLeft = styled(Stack)`
+  margin-right: 2em;
 `;


### PR DESCRIPTION
#4 

## やったこと
- informItemのview
- 最終送信元/つんつんかで表記を変更
![スクリーンショット 2022-09-11 1 14 53](https://user-images.githubusercontent.com/79315807/189492165-1ab114c7-8f21-4189-a9ac-21825741e3fa.png)
![スクリーンショット 2022-09-11 1 15 49](https://user-images.githubusercontent.com/79315807/189492209-56898839-d72a-4c27-8e3e-1118502c0aad.png)
![スクリーンショット 2022-09-11 1 16 18](https://user-images.githubusercontent.com/79315807/189492235-7c731382-8cad-45f6-a779-a9b635f30615.png)
![スクリーンショット 2022-09-11 1 16 38](https://user-images.githubusercontent.com/79315807/189492247-ef43972c-bc3c-42e7-a808-94e0763f766d.png)

## 相談したいこと
- 最終履歴でメッセージをやりとりしている場合、最後のメッセージ内容まで表示するか（現在は送った/受け取ったという情報のみ）
- そもそもどのようなメッセージをinformitemの対象にするか
  - 私のイメージは全ての人とのチャットでしたが、こちらから返信済みorつんつん済みのものは対象外にするというパターンもあると思ったので確認しておきたいです
- 最終履歴がメッセージの場合でもアイコンはつんつんボタンのままで良いか